### PR TITLE
Feature/firebase enhance

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -8,7 +8,7 @@
     <ul>
       <li v-for='todo in todos' :key='todo.id'>
         <input type='checkbox' v-model='todo.isDone' @click='toggle(todo.id)' >
-        <span v-bind:class='{done: todo.isDone}'>{{todo}}</span>
+        <span v-bind:class='{done: todo.isDone}'>{{todo.name}}</span>
         <span @click='deleteTask(todo.id)' class='xButton'>[x]</span>
         </li>
     </ul>
@@ -150,9 +150,11 @@ export default {
       this.todos.forEach(todo => this.unCheck(todo.id))
     },
     isAllChecked: function(){
-      if(this.todos.findIndex(todo=> !todo.isDone) ===-1){
+      if(this.todos.findIndex(todo=> !todo.isDone) ===-1){ 
+        // 完了していないのが一つもなければ、true
         return true
       }
+      // 完了していないのが一つでもあれば false
       return false
     }
   },

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -33,8 +33,6 @@ export default {
     }
   },
   created: function () {
-    // this.todos = JSON.parse(localStorage.getItem("todos")) || [];
-    const me = this
     const ref = this.db.collection('todos')
     // 変更データを取得するメソッドを使用する。
     // ココは、refのデータに変更があった場合コールバックされる
@@ -56,7 +54,7 @@ export default {
             // added は、初期表示時と、データをaddしたとき
             // idが""でないときは初期表示なので単純push
             if (task.id !== "") {
-              me.todos.push(task)
+              this.todos.push(task)
             }else{
               // なにもしない(addTaskメソッドでpush済み)
             }
@@ -69,10 +67,10 @@ export default {
               this.todos.push(task)
             } else {
               // indexが見つかるときは、該当行を更新すればいいが、
-              // me.todos[index] = change.doc.data()
+              // this.todos[index] = change.doc.data()
               // これはVue.jsがViewを更新してくれない
-              // me.$forceUpdate() // これかもしくは$setをつかう
-              this.$set(me.todos, index, task)
+              // this.$forceUpdate() // これかもしくは$setをつかう
+              this.$set(this.todos, index, task)
             }
             break
           case "removed":


### PR DESCRIPTION

追加更新を受け取るためにFireStoreの処理を見なおし中 
createで、
const ref = this.db.collection('todos')
ref.get().then(querySnapshot => {
        querySnapshot.forEach(doc => {

とだけやっていた箇所に、

 ref.onSnapshot(querySnapshot => {
      querySnapshot.docChanges().forEach(change => {
        const task = change.doc.data()
        console.log("task: "+ JSON.stringify(task)+" "+change.type)

という、Firebaseで更新(追加・変更・削除) されたデータを検知するハンドラを追加。

このハンドラで、

追加時: todos配列に追加
変更時: todos配列内のデータを変更(一部、配列への追加もあるが)
削除時: todos配列内のデータを削除

などの処理を実装することにした。
その代わり各種、CRUDする処理はシンプルに。

ついでに、

 <input type='checkbox' v-model='todo.isDone' @click='done(todo)' >

@clickしたときわたされるtodoについて、todo.isDone の値が、ブラウザによって、safariは変更後、firefox,chromeは変更前？
とかだったりするようで、DBからいったん値を取って、その値をtoggleするようにした

    toggle: function(key){
      let target ={}
      const ref = this.db.collection('todos').doc(key)
      ref.get().then(docref=>{
        target = docref.data()
        target.isDone = !target.isDone
        ref.set(target)
      })
    },
こんなかんじ。



