### PR TITLE
エラー処理部は、ポップアップのリンクを二回押したり、

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -154,7 +154,9 @@ export default {
         .catch(function (error) {
           const errorCode = error.code
           const errorMessage = error.message
-          alert(errorMessage)
+          // alert(errorMessage) 
+          // ↑二回ダイアログを出したりとか、ポップアップ閉じたりとか、結構な頻度で発生するエラーだった。コレ。
+          console.log(errorCode,errorMessage)
         })
     }
   }


### PR DESCRIPTION
ポップアップで何もしないで閉じたときなど結構な頻度で発生するので、 alert で表示するのはよろしくないのでコメントアウト